### PR TITLE
Fix npm install (fails on react-game-kit)

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "mobx": "^2.5.1",
     "mobx-react": "^3.5.5",
     "react": "15.3.1",
-    "react-game-kit": "file:///Users/kenwheeler/Projects/react-game-kit",
+    "react-game-kit": "0.0.2",
     "react-native": "0.33.0",
     "react-native-fit-image": "^1.3.3"
   },


### PR DESCRIPTION
Use version number instead of path for react-game-kit.